### PR TITLE
Sparkpluggw key value engine

### DIFF
--- a/exporter.go
+++ b/exporter.go
@@ -192,7 +192,7 @@ func (e *spplugExporter) receiveMessage() func(mqtt.Client, mqtt.Message) {
 		}
 
 		topic := m.Topic()
-		log.Infof("Received message: %s\n", topic)
+		log.Debugf("Received message: %s\n", topic)
 		log.Debugf("%s\n", pbMsg.String())
 
 		// Get the labels and value for the labels from the topic and constants
@@ -288,7 +288,7 @@ func (e *spplugExporter) receiveMessage() func(mqtt.Client, mqtt.Message) {
 				log.Debugf("Error %v converting data type for metric %s\n",
 					err, metricName)
 			} else {
-				log.Debugf("Event: %s: Metric name(%s) Metric value(%g) Applied labels(%s) Applied labels values(%s) siteLabelValues(%s)\n",
+				log.Infof("%s: Metric name(%s) Metric value(%g) Applied labels(%s) Applied labels values(%s) siteLabelValues(%s)\n",
 					eventString, metricName, metricVal, metricLabels, metricLabelValues, siteLabelValues)
 
 				e.metrics[metricName][labelIndex].prommetric.With(metricLabelValues).Set(metricVal)

--- a/exporter.go
+++ b/exporter.go
@@ -288,8 +288,10 @@ func (e *spplugExporter) receiveMessage() func(mqtt.Client, mqtt.Message) {
 				log.Debugf("Error %v converting data type for metric %s\n",
 					err, metricName)
 			} else {
-				log.Infof("%s: Metric name(%s) Metric value(%g) Applied labels(%s) Applied labels values(%s) siteLabelValues(%s)\n",
-					eventString, metricName, metricVal, metricLabels, metricLabelValues, siteLabelValues)
+				log.Infof("%s: name (%s) value (%g) labels: (%s)\n",
+							eventString, metricName, metricVal, metricLabelValues)
+				log.Debugf("metriclabels: (%s) siteLabelValues: (%s)\n",
+							metricLabels, siteLabelValues)
 
 				e.metrics[metricName][labelIndex].prommetric.With(metricLabelValues).Set(metricVal)
 				e.metrics[SPLastTimePushedMetric][0].prommetric.With(siteLabelValues).SetToCurrentTime()

--- a/exporter.go
+++ b/exporter.go
@@ -259,7 +259,7 @@ func (e *spplugExporter) receiveMessage() func(mqtt.Client, mqtt.Message) {
 				// If they are we update an existing metric
 				if !labelSetExists {
 
-					eventString = "Creating new timeseries for existing metric name"
+					eventString = "Creating new timeseries for existing metric"
 					newMetric.promlabel = append(newMetric.promlabel,
 						metricLabels...)
 
@@ -275,7 +275,7 @@ func (e *spplugExporter) receiveMessage() func(mqtt.Client, mqtt.Message) {
 					e.metrics[metricName][labelIndex].promlabel = metricLabels
 				}
 			} else {
-				eventString = "Creating new metric name and timeseries"
+				eventString = "Creating metric"
 				newMetric.promlabel = append(newMetric.promlabel,
 					metricLabels...)
 				newMetric.prommetric = createNewMetric(metricName,
@@ -289,9 +289,10 @@ func (e *spplugExporter) receiveMessage() func(mqtt.Client, mqtt.Message) {
 					err, metricName)
 			} else {
 				log.Infof("%s: name (%s) value (%g) labels: (%s)\n",
-							eventString, metricName, metricVal, metricLabelValues)
+					eventString, metricName, metricVal, metricLabelValues)
+
 				log.Debugf("metriclabels: (%s) siteLabelValues: (%s)\n",
-							metricLabels, siteLabelValues)
+					metricLabels, siteLabelValues)
 
 				e.metrics[metricName][labelIndex].prommetric.With(metricLabelValues).Set(metricVal)
 				e.metrics[SPLastTimePushedMetric][0].prommetric.With(siteLabelValues).SetToCurrentTime()

--- a/exporter.go
+++ b/exporter.go
@@ -7,7 +7,6 @@ import (
 	"sync"
 	"time"
 	"strings"
-	"reflect"
 
 	pb "github.com/IHI-Energy-Storage/sparkpluggw/Sparkplug"
 	mqtt "github.com/eclipse/paho.mqtt.golang"
@@ -67,6 +66,26 @@ type spplugExporter struct {
 
 	// Holds the mertrics collected
 	metrics        map[string]*prometheus.GaugeVec
+	
+	// [metricName]
+	// - prometheus.Labels{}
+	//   *prometheus.GaugeVec
+	// - 
+	// -
+	// -
+	// 
+	// [ess_seq]
+	// - ["comptest"]
+	//    Metric Pointer 
+	// - ["jason", "bob"]
+	//   Metric Pointer
+	// - NEW ENtRY 
+	
+	// map: key metricName value: array new a new datastruture
+	{ 
+		prometheus.Labels{}
+		*prometheus.GaugeVec
+	}
 	counterMetrics map[string]*prometheus.CounterVec
 }
 
@@ -198,22 +217,20 @@ func (e *spplugExporter) receiveMessage() func(mqtt.Client, mqtt.Message) {
 			siteLabelValues["sp_group_id"],
 			siteLabelValues["sp_edge_node_id"])
 
-		// Sparkplug messages contain multiple metrics within them
-		// traverse them and process them
-
-		log.Infof("type for siteLabels: %s\n", reflect.TypeOf(siteLabels))
-		log.Infof("type for siteLabels: %s\n", reflect.TypeOf(siteLabelValues))
-		// metricLabelValues = siteLabelValues
-
 		metricList := pbMsg.GetMetrics()
 		log.Infof("Received message in processMetric: %s\n", metricList)
 		for _, metric := range metricList {
 
 			metricLabels := siteLabels
-			metricLabelValues := siteLabelValues
+			metricLabelValues := cloneLabelSet(siteLabelValues)
+			
+			log.Debugf("Check the data structures: (%x %x)",
+			 		   siteLabelValues, metricLabelValues)
 
-			log.Infof("Received message in loop for metricName: %s\n", metric)
 			newLabelname, metricName, err := getMetricName(metric)
+
+			log.Infof("Received message for metric: %s", metricName)
+			
 			if newLabelname!=nil {
 				for list := 0; list < len(newLabelname); list++ {
 					parts := strings.Split(newLabelname[list], ":")
@@ -223,7 +240,6 @@ func (e *spplugExporter) receiveMessage() func(mqtt.Client, mqtt.Message) {
 				}
 			}
 
-			log.Infof("Received message in loop for metricName: %s siteLabels: %s metricLabelValues: %s\n", metric, metricLabels, metricLabelValues)
 			if  err != nil {
 				if metricName != "Device Control/Rebirth" {
 					log.Errorf("Error: %s %s %v  \n", 	siteLabelValues["sp_edge_node_id"], metricName, err)
@@ -232,9 +248,13 @@ func (e *spplugExporter) receiveMessage() func(mqtt.Client, mqtt.Message) {
 
 				continue
 			}
-			log.Debugf("e.metrics[metricName] : %v", *e)
-			if _, ok := e.metrics[metricName]; !ok {
 
+			// if metricName is not within the e.metrics OR
+			// if metricLabels (note you will need a function to compare maps) is not within e.metrics[metricName], then you need to create a new metric
+			_, metricNameExists := e.metrics[metricName]
+
+			if (!metricNameExists ||
+			   (!compareLabelSet(e.metrics[metricName], metricLabels))) {
 				eventString = "Creating metric"
 
 				e.metrics[metricName] = prometheus.NewGaugeVec(
@@ -247,18 +267,18 @@ func (e *spplugExporter) receiveMessage() func(mqtt.Client, mqtt.Message) {
 			} else {
 				eventString = "Updating metric"
 			}
-			log.Debugf("e.metrics[metricName] : %v", e.metrics[metricName])
+
 			if metricVal, err := convertMetricToFloat(metric); err != nil {
 				log.Debugf("Error %v converting data type for metric %s\n",
 					err, metricName)
 			} else {
+				log.Debugf("%s: name(%s) value(%g) labels(%s) values(%s)\n",
+							eventString, metricName, metricVal, metricLabels, metricLabelValues)
 
-
-				log.Debugf("love you: %s %s : %g\n", eventString, metricName, metricVal)
+			    // NEED to reference e.metric[metricName][metricLabels]
 				e.metrics[metricName].With(metricLabelValues).Set(metricVal)
 				e.metrics[SPLastTimePushedMetric].With(siteLabelValues).SetToCurrentTime()
 				e.counterMetrics[SPPushTotalMetric].With(siteLabelValues).Inc()
-
 			}
 		}
 	}

--- a/utilities.go
+++ b/utilities.go
@@ -41,6 +41,17 @@ func sendMQTTMsg(c mqtt.Client, pbMsg *pb.Payload,
 	return true
 }
 
+func cloneLabelSet(labels prometheus.Labels) (prometheus.Labels) {
+	newLabels := prometheus.Labels{}
+
+	for key, value := range labels {
+	  newLabels[key] = value
+	}
+	
+	return newLabels
+}
+
+
 func prepareLabelsAndValues(topic string) ([]string, prometheus.Labels, bool) {
 	var labels []string
 	t := strings.TrimPrefix(topic, *prefix)

--- a/utilities.go
+++ b/utilities.go
@@ -63,6 +63,24 @@ func compareLabelSet(testlabels prometheus.Labels, metricLabels []string) (bool)
 	return false
 }
 
+// func addNewLabels(metricName string, metricLabels []string)(prometheusmetric)  {
+// 	i := 0
+//
+// }
+
+func createNewMetric(metricName string, metricLabels []string)(*prometheus.GaugeVec)  {
+	var newMetric prometheusmetric
+	// eventString := "Creating metric"
+	newMetric.prommetric  = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: metricName,
+			Help: "Metric pushed via MQTT",
+		},
+		metricLabels,
+	)
+	return newMetric.prommetric
+}
+
 func prepareLabelsAndValues(topic string) ([]string, prometheus.Labels, bool) {
 	var labels []string
 	t := strings.TrimPrefix(topic, *prefix)

--- a/utilities.go
+++ b/utilities.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"strings"
 	"reflect"
+	// "fmt"
 
 	pb "github.com/IHI-Energy-Storage/sparkpluggw/Sparkplug"
 	mqtt "github.com/eclipse/paho.mqtt.golang"
@@ -47,10 +48,20 @@ func cloneLabelSet(labels prometheus.Labels) (prometheus.Labels) {
 	for key, value := range labels {
 	  newLabels[key] = value
 	}
-	
+
 	return newLabels
 }
 
+func compareLabelSet(testlabels prometheus.Labels, metricLabels []string) (bool) {
+	for key := range testlabels {
+		for km := range metricLabels{
+			if testlabels[key] == metricLabels[km] {
+				return true
+		}
+		}
+	}
+	return false
+}
 
 func prepareLabelsAndValues(topic string) ([]string, prometheus.Labels, bool) {
 	var labels []string

--- a/utilities.go
+++ b/utilities.go
@@ -52,21 +52,48 @@ func cloneLabelSet(labels prometheus.Labels) (prometheus.Labels) {
 	return newLabels
 }
 
-func compareLabelSet(testlabels prometheus.Labels, metricLabels []string) (bool) {
-	for key := range testlabels {
-		for km := range metricLabels{
-			if testlabels[key] == metricLabels[km] {
-				return true
+// In order for 2 label sets to match, they have to have the exact same
+// number of entries and the exact same entries orthogonal or the order
+// that they are stored
+
+func compareLabelSet(metricSet []prometheusmetric,
+					newLabels []string) (bool, int) {
+	returnCode := true
+	returnIndex := 0
+
+	for _, existingMetric := range metricSet {
+		tmpIndex := 0
+
+		// Make sure that both label sets have the same number of entries
+		if len(existingMetric.promlabel) == len(newLabels) {
+			// Initially we believe all labeles are unverified
+			// As we verify we decrement, if we end up with something > 0
+			// we know the set does not match
+
+			mismatchedLabels := len(newLabels)
+
+			for _, newLabel := range newLabels {
+				// Compare the current new label to everything in existing
+				// label set
+				for _, existingLabel := range existingMetric.promlabel {
+					if existingLabel == newLabel {
+						mismatchedLabels--
+						break
+					}
+				}
+			}
+
+			if mismatchedLabels == 0 {
+				returnCode = true
+				returnIndex = tmpIndex
+			}
+			}
+
+		tmpIndex++
 		}
-		}
-	}
-	return false
+	return returnCode, returnIndex
 }
 
-// func addNewLabels(metricName string, metricLabels []string)(prometheusmetric)  {
-// 	i := 0
-//
-// }
 
 func createNewMetric(metricName string, metricLabels []string)(*prometheus.GaugeVec)  {
 	var newMetric prometheusmetric

--- a/utilities.go
+++ b/utilities.go
@@ -109,8 +109,7 @@ func prepareLabelsAndValues(topic string) ([]string, prometheus.Labels, bool) {
 	t := strings.TrimPrefix(topic, *prefix)
 	t = strings.TrimPrefix(t, "/")
 	parts := strings.Split(t, "/")
-	log.Debugf("Metric after spliting the wrt / and its length: %s: %d\n", parts, len(parts))
-
+	
 	// 6.1.3 covers 9 message types, only process device data
 	// Sparkplug puts 5 key namespacing elements in the topic name
 	// these are being parsed and will be added as metric labels
@@ -132,7 +131,7 @@ func prepareLabelsAndValues(topic string) ([]string, prometheus.Labels, bool) {
 	}
 
 	labelValues := prometheus.Labels{}
-	log.Debugf("Label values it recieve with prometheus.Labels{}: %s\n", prometheus.Labels{})
+
 	// Labels are created from the topic parsing above and compared against
 	// the set of labels for this metric.   If this is a unique set then it will
 	// be stored and the metric will be treated as unique and new.   If the

--- a/utilities.go
+++ b/utilities.go
@@ -18,6 +18,7 @@ const (
 	SPGroupID				string = "sp_group_id"
 	SPEdgeNodeID			string = "sp_edge_node_id"
 	SPDeviceID				string = "sp_device_id"
+	SPkeyID					string = "sp_key_id"
 	SPMQTTTopic				string = "sp_mqtt_topic"
 	SPMQTTServer			string = "sp_mqtt_server"
 )
@@ -77,12 +78,16 @@ func prepareLabelsAndValues(topic string) ([]string, prometheus.Labels, bool) {
 	labelValues[SPGroupID] = parts[1]
 	labelValues[SPEdgeNodeID] = parts[3]
 	labelValues[SPDeviceID] = parts[4]
+	if len(parts)>5{
+		labelValues[SPkeyID] = parts[5]
+	}
+
 
 	return labels, labelValues, true
 }
 
 func getLabelSet() []string {
-	return []string{SPNamespace, SPGroupID, SPEdgeNodeID, SPDeviceID}
+	return []string{SPNamespace, SPGroupID, SPEdgeNodeID, SPDeviceID, SPkeyID}
 }
 
 func getServiceLabelSetandValues() ([]string, map[string]string) {

--- a/utilities.go
+++ b/utilities.go
@@ -44,13 +44,14 @@ func prepareLabelsAndValues(topic string) ([]string, prometheus.Labels, bool) {
 	t := strings.TrimPrefix(topic, *prefix)
 	t = strings.TrimPrefix(t, "/")
 	parts := strings.Split(t, "/")
+	log.Debugf("first test to check the lengh for Metricx: %s\n", parts)
 
 	// 6.1.3 covers 9 message types, only process device data
 	// Sparkplug puts 5 key namespacing elements in the topic name
 	// these are being parsed and will be added as metric labels
 
 	if (parts[2] == "DDATA") || (parts[2] == "DBIRTH") {
-		if len(parts) != 5 {
+		if len(parts) != 6 {
 			log.Debugf("Ignoring topic %s, does not comply with Sparkspec\n", t)
 			return nil, nil, false
 		}
@@ -121,6 +122,7 @@ func getMetricName(metric *pb.Payload_Metric)(string, error) {
 	var errUnexpectedType error
 
 	metricName := model.LabelValue(metric.GetName())
+	log.Infof("Received message for testt: %s\n", metricName)
 
 	if  model.IsValidMetricName(metricName) == true {
 		errUnexpectedType = nil

--- a/utilities.go
+++ b/utilities.go
@@ -3,8 +3,7 @@ package main
 import (
 	"errors"
 	"strings"
-	"reflect"
-	// "fmt"
+
 
 	pb "github.com/IHI-Energy-Storage/sparkpluggw/Sparkplug"
 	mqtt "github.com/eclipse/paho.mqtt.golang"
@@ -58,14 +57,14 @@ func cloneLabelSet(labels prometheus.Labels) (prometheus.Labels) {
 
 func compareLabelSet(metricSet []prometheusmetric,
 					newLabels []string) (bool, int) {
-	returnCode := true
+	returnCode := false
 	returnIndex := 0
-
+	tmpIndex := 0
 	for _, existingMetric := range metricSet {
-		tmpIndex := 0
 
 		// Make sure that both label sets have the same number of entries
 		if len(existingMetric.promlabel) == len(newLabels) {
+
 			// Initially we believe all labeles are unverified
 			// As we verify we decrement, if we end up with something > 0
 			// we know the set does not match
@@ -75,7 +74,7 @@ func compareLabelSet(metricSet []prometheusmetric,
 			for _, newLabel := range newLabels {
 				// Compare the current new label to everything in existing
 				// label set
-				for _, existingLabel := range existingMetric.promlabel {
+				for _, existingLabel := range existingMetric.promlabel{
 					if existingLabel == newLabel {
 						mismatchedLabels--
 						break
@@ -83,6 +82,7 @@ func compareLabelSet(metricSet []prometheusmetric,
 				}
 			}
 
+			log.Debugf("mismatchedLabels: %d tmpIndex: %d\n",mismatchedLabels, tmpIndex)
 			if mismatchedLabels == 0 {
 				returnCode = true
 				returnIndex = tmpIndex
@@ -97,7 +97,7 @@ func compareLabelSet(metricSet []prometheusmetric,
 
 func createNewMetric(metricName string, metricLabels []string)(*prometheus.GaugeVec)  {
 	var newMetric prometheusmetric
-	// eventString := "Creating metric"
+
 	newMetric.prommetric  = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: metricName,
@@ -135,9 +135,8 @@ func prepareLabelsAndValues(topic string) ([]string, prometheus.Labels, bool) {
 		labels = getLabelSet()
 	}
 
-	log.Infof("prometheus.Labels{}: %s\n", prometheus.Labels{})
 	labelValues := prometheus.Labels{}
-
+	log.Debugf("prometheus.Labels{}: %s\n", prometheus.Labels{})
 	// Labels are created from the topic parsing above and compared against
 	// the set of labels for this metric.   If this is a unique set then it will
 	// be stored and the metric will be treated as unique and new.   If the
@@ -188,7 +187,7 @@ func getNodeLabelSet() []string {
 func getMetricName(metric *pb.Payload_Metric)([]string, string, error) {
 	var errUnexpectedType error
 	var labelvalues []string
-	log.Info("data checked",(reflect.TypeOf(metric.GetName())))
+
 	metricName := metric.GetName()
 
 	if strings.Contains(metricName, "/")  == true && metricName != "Device Control/Rebirth"{
@@ -199,7 +198,7 @@ func getMetricName(metric *pb.Payload_Metric)([]string, string, error) {
 			labelvalues = append(labelvalues, parts[metlen])
 
 		}
-	log.Infof("Received message for labelvalues: %s\n", labelvalues)
+	log.Debugf("Received message for labelvalues: %s\n", labelvalues)
 	}
 	metricNameL := model.LabelValue(metricName)
 


### PR DESCRIPTION
This will create an ability to sparkpluggw to add dynamically key value pair attached with metrics with different or same name in different folder archtecture

`updating metric: name(ess_seq_test) value(1555) labels([sp_namespace sp_group_id sp_edge_node_id sp_device_id]) values(map[sp_device_id:sunrise:z0:c1:ess:1:service:1 sp_edge_node_id:sunrise:_:c1:igw:1:service:1 sp_group_id:v2:prod:ess sp_namespace: XXXXX]) siteLabelValues(map[sp_device_id:sunrise:z0:c1:ess:1:service:1 sp_edge_node_id:sunrise:_:c1:igw:1:service:1 sp_group_id:v2:prod:ess sp_namespace: XXXXX])`

` Creating new metric name and timeseries: name(ess_zones_total) value(1) labels([sp_namespace sp_group_id sp_edge_node_id sp_device_id comptest]) values(map[comptest:1 sp_device_id:sunrise:z0:c1:ess:1:service:1 sp_edge_node_id:sunrise:_:c1:igw:1:service:1 sp_group_id:v2:prod:ess sp_namespace:XXXXX]) siteLabelValues(map[sp_device_id:sunrise:z0:c1:ess:1:service:1 sp_edge_node_id:sunrise:_:c1:igw:1:service:1 sp_group_id:v2:prod:ess sp_namespace:XXXXX])`