### PR TITLE
rectifying the newmetric.promlabel appending issue

### DIFF
--- a/exporter.go
+++ b/exporter.go
@@ -181,9 +181,9 @@ func (e *spplugExporter) receiveMessage() func(mqtt.Client, mqtt.Message) {
 	return func(c mqtt.Client, m mqtt.Message) {
 		mutex.Lock()
 		defer mutex.Unlock()
-		var newMetric prometheusmetric
-		var pbMsg pb.Payload
-		var eventString string
+
+		var   pbMsg pb.Payload
+		var   eventString string
 
 		// Unmarshal MQTT message into Google Protocol Buffer
 		if err := proto.Unmarshal(m.Payload(), &pbMsg); err != nil {
@@ -212,6 +212,7 @@ func (e *spplugExporter) receiveMessage() func(mqtt.Client, mqtt.Message) {
 
 		for _, metric := range metricList {
 
+			var newMetric prometheusmetric
 			metricLabels := siteLabels
 			metricLabelValues := cloneLabelSet(siteLabelValues)
 


### PR DESCRIPTION
Rectified error:
An error has occurred while serving metrics:
```
38 error(s) occurred:
* collected metric "ess_zones_total" { label:<name:"comptest" value:"1" > label:<name:"sp_device_id" value:"sunrise:z0:c1:ess:1:service:1" > label:<name:"sp_edge_node_id" value:"sunrise:_:c1:igw:1:service:1" > label:<name:"sp_group_id" value:"v2:prod:ess" > label:<name:"sp_namespace" value:"spBv1.0" > gauge:<value:0 > } was collected before with the same name and label values
```

Now its fully deployable code with multiple scenario test verified
`HELP ess_available_modes_flags Metric pushed via MQTT
TYPE ess_available_modes_flags gauge
ess_available_modes_flags{comptest="1",sp_device_id="sunrise:z0:c1:ess:1:service:1",sp_edge_node_id="sunrise:_:c1:igw:1:service:1",sp_group_id="v2:prod:ess",sp_namespace="spBv1.0"} 7.39311616e+08
HELP ess_current Metric pushed via MQTT
TYPE ess_current gauge
ess_current{sp_device_id="sunrise:z0:c1:ess:1:service:1",sp_edge_node_id="sunrise:_:c1:igw:1:service:1",sp_group_id="v2:prod:ess",sp_namespace="spBv1.0"} -312
ess_current{comptest="1",sp_device_id="sunrise:z0:c1:ess:1:service:1",sp_edge_node_id="sunrise:_:c1:igw:1:service:1",sp_group_id="v2:prod:ess",sp_namespace="spBv1.0"} -312
 HELP ess_energy_avail Metric pushed via MQTT
TYPE ess_energy_avail gauge`